### PR TITLE
Add PartOf=openchami.target to service containers

### DIFF
--- a/systemd/containers/bss.container
+++ b/systemd/containers/bss.container
@@ -2,6 +2,7 @@
 Description=The bss container
 Requires=bss-init.service opaal.service
 After=bss-init.service opaal.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=bss

--- a/systemd/containers/cloud-init-server.container
+++ b/systemd/containers/cloud-init-server.container
@@ -2,6 +2,7 @@
 Description=The cloud-init-server container
 Requires=smd.service opaal.service
 After=smd.service opaal.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=cloud-init-server

--- a/systemd/containers/coresmd.container
+++ b/systemd/containers/coresmd.container
@@ -2,6 +2,7 @@
 Description=The coresmd container
 Requires=haproxy.service
 After=haproxy.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=coresmd

--- a/systemd/containers/haproxy.container
+++ b/systemd/containers/haproxy.container
@@ -2,6 +2,7 @@
 Description=The haproxy container
 Requires=opaal.service bss.service acme-deploy.service cloud-init-server.service smd.service
 After=opaal.service bss.service acme-deploy.service cloud-init-server.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=haproxy

--- a/systemd/containers/hydra.container
+++ b/systemd/containers/hydra.container
@@ -2,6 +2,7 @@
 Description=The hydra container
 Requires=hydra-migrate.service
 After=hydra-migrate.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=hydra

--- a/systemd/containers/opaal-idp.container
+++ b/systemd/containers/opaal-idp.container
@@ -2,6 +2,7 @@
 Description=The opaal-idp container
 Requires=hydra-gen-jwks.service
 After=hydra-gen-jwks.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=opaal-idp

--- a/systemd/containers/opaal.container
+++ b/systemd/containers/opaal.container
@@ -2,6 +2,7 @@
 Description=The opaal container
 Requires=opaal-idp.service
 After=opaal-idp.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=opaal

--- a/systemd/containers/postgres.container
+++ b/systemd/containers/postgres.container
@@ -1,5 +1,6 @@
 [Unit]
 Description=The postgres container
+PartOf=openchami.target
 
 [Container]
 ContainerName=postgres

--- a/systemd/containers/smd.container
+++ b/systemd/containers/smd.container
@@ -2,6 +2,7 @@
 Description=The smd container
 Requires=smd-init.service opaal.service
 After=smd-init.service opaal.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=smd

--- a/systemd/containers/step-ca.container
+++ b/systemd/containers/step-ca.container
@@ -1,5 +1,6 @@
 [Unit]
 Description=The step-ca container
+PartOf=openchami.target
 
 [Container]
 ContainerName=step-ca


### PR DESCRIPTION
This is so that `systemctl stop openchami.target` will stop all of the OpenCHAMI service containers that were started with `systemctl start openchami.target`.

The image-server container and one-shot containers are not included in this update.