### PR TITLE
fix(cloud-init): enable impersonation

### DIFF
--- a/systemd/containers/cloud-init-server.container
+++ b/systemd/containers/cloud-init-server.container
@@ -12,6 +12,9 @@ Image=ghcr.io/openchami/cloud-init:v1.2.0
 # Environment Variables
 EnvironmentFile=/etc/openchami/configs/openchami.env
 
+# Run cloud-init-server with impersonation enabled
+Exec=/usr/local/bin/cloud-init-server --impersonation=true
+
 # Networks for the Container to use
 Network=openchami-internal.network
 


### PR DESCRIPTION
Enable impersonation in cloud-init-server container so that querying via `ochaMi cloud-init` commands doesn't return 404 for valid nodes.