### PR TITLE
fix: `tls: bad record MAC` and other dependency issues

### DIFF
--- a/systemd/containers/acme-register.container
+++ b/systemd/containers/acme-register.container
@@ -9,7 +9,7 @@ HostName=demo.openchami.cluster
 Image=docker.io/neilpang/acme.sh:3.1.1
 
 # Volumes
-Volume=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/root_ca/root_ca.crt:ro,Z
+Volume=step-root-ca.volume:/root_ca/:ro
 Volume=acme-certs:/acme.sh:z
 
 # Networks for the Container to use

--- a/systemd/containers/bss-init.container
+++ b/systemd/containers/bss-init.container
@@ -1,6 +1,7 @@
 [Unit]
 Description=The bss-init container
-Wants=smd.service postgres.service
+Wants=smd.service
+Requires postgres.service
 
 [Container]
 ContainerName=bss-init

--- a/systemd/containers/coresmd.container
+++ b/systemd/containers/coresmd.container
@@ -15,7 +15,7 @@ AddCapability=NET_ADMIN
 AddCapability=NET_RAW
 
 # Volumes
-Volume=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/root_ca/root_ca.crt:ro,Z
+Volume=step-root-ca:/root_ca/root_ca.crt:ro,Z
 Volume=/etc/openchami/configs/coredhcp.yaml:/etc/coredhcp/config.yaml:ro,Z
 
 # Networks for the Container to use

--- a/systemd/containers/haproxy.container
+++ b/systemd/containers/haproxy.container
@@ -2,6 +2,7 @@
 Description=The haproxy container
 Wants=bss.service cloud-init-server.service smd.service
 After=opaal.service smd.service bss.service acme-deploy.service cloud-init-server.service
+Requires=acme-deploy.service
 PartOf=openchami.target
 
 [Container]

--- a/systemd/containers/smd-init.container
+++ b/systemd/containers/smd-init.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=The smd-init container
-Wants=postgres.service
+Requires=postgres.service
 After=postgres.service
 
 [Container]


### PR DESCRIPTION
Introduce fixes that solve some TLS issues.

Three fixes:

1. Make `haproxy.container` require `acme-deploy.container` (solid black arrow in diagram below) so that certificate generation does not silently fail.
2. Revert to using `step-root-ca` volume for generate certificates.
   - Otherwise, a `local error: tls: bad record MAC` error occurs in `step-ca` when `acme-register` tries to fetch them.
3. Make `smd-init` and `bss-init` require `postgres` so that they run before SMD and BSS, respectively.
   - Otherwise, SMD will complain endlessly about not being able to find the "system" table and CoreSMD will fail. 

### New Dependency Graph

- Solid black: `Requires`
- Grey: `Wants`

![openchami-cg-head](https://github.com/user-attachments/assets/6a343853-133f-48ba-aa50-17640355df74)
