### PR TITLE
fix: don't include symbols in secrets

### DIFF
--- a/openchami.spec
+++ b/openchami.spec
@@ -12,6 +12,7 @@ BuildArch:      noarch
 Requires:       podman
 Requires:       jq
 Requires:       curl
+Requires(post): coreutils
 
 %description
 This package installs all the necessary files for OpenChami, mostly the quadlet/systemd-unit files.

--- a/scripts/bootstrap_openchami.sh
+++ b/scripts/bootstrap_openchami.sh
@@ -5,7 +5,8 @@ source /etc/profile.d/openchami.sh
 # Function to generate a random password
 generate_random_password() {
   # Generate a random password with 16 characters
-  openssl rand -base64 16
+  local num_chars=${1:-16}
+  dd bs=512 if=/dev/urandom count=1 2>/dev/null | tr -dc '[:alnum:]' | fold -w "${num_chars}" | head -n 1
 }
 
 # Function to create a secret if it doesn't exist


### PR DESCRIPTION
Using base64 to generate passwords for the postgres databases can cause certain symbols that are generated (e.g. `/`) to cause parsing of the Postgres DSN to fail:

```
May 21 15:30:47 ip-10-10-8-127.us-west-1.compute.internal hydra-migrate[43645]: cannot parse `postgres://hydra-user:xxxxxx@postgres:5432/hydradb?sslmode=disable`: failed to parse as URL (parse "postgres://hydra-user:t+lCE/YpQlqF+Je3NQGjbg==@postgres:5432/hydradb?sslmode=disable": invalid port ":t+lCE" after host)
May 21 15:30:47 ip-10-10-8-127.us-west-1.compute.internal podman[41603]: 2025-05-21 15:30:47.145576858 +0000 UTC m=+11.345083956 container died
```

This PR switches to the password generation method that the [quickstart](https://github.com/OpenCHAMI/deployment-recipes/blob/cd91773fb7a3242a6109d87b89ccf8b06c634cf8/quickstart/generate-configs.sh#L70) uses, using `tr -dc [:alnum:]` to ensure that only alphanumeric characters are used.