### PR TITLE
chore: switch from `tr` to `openssl` for secret generation

### DIFF
--- a/openchami.spec
+++ b/openchami.spec
@@ -13,6 +13,7 @@ Requires:       podman
 Requires:       jq
 Requires:       curl
 Requires(post): coreutils
+Requires(post): openssl
 
 %description
 This package installs all the necessary files for OpenChami, mostly the quadlet/systemd-unit files.

--- a/scripts/bootstrap_openchami.sh
+++ b/scripts/bootstrap_openchami.sh
@@ -6,7 +6,7 @@ source /etc/profile.d/openchami.sh
 generate_random_password() {
   # Generate a random password with 16 characters
   local num_chars=${1:-16}
-  openssl rand -base64 "${num_chars}" | openssl dgst | cut -d' ' -f2
+  openssl rand -base64 "${num_chars}" | openssl dgst | cut -d' ' -f2 | fold -w "${num_chars}" | head -n 1
 }
 
 # Function to create a secret if it doesn't exist

--- a/scripts/bootstrap_openchami.sh
+++ b/scripts/bootstrap_openchami.sh
@@ -6,7 +6,7 @@ source /etc/profile.d/openchami.sh
 generate_random_password() {
   # Generate a random password with 16 characters
   local num_chars=${1:-16}
-  dd bs=512 if=/dev/urandom count=1 2>/dev/null | tr -dc '[:alnum:]' | fold -w "${num_chars}" | head -n 1
+  openssl rand -base64 "${num_chars}" | openssl dgst | cut -d' ' -f2
 }
 
 # Function to create a secret if it doesn't exist


### PR DESCRIPTION
This is more cross-platform and achieves the same goal as #10.

```
openssl rand -base64 32 | openssl dgst | cut -d' ' -f2
```

Example return value:

```
4955720fc971a7a429b2072ec6df2f2345823d2e1e7fe416996f53fa5cd2accb
```

Example Postres DSN secret:

```
"SecretData": "hmsds:smd-user:4955720fc971a7a429b2072ec6df2f2345823d2e1e7fe416996f53fa5cd2accb,bssdb:bss-user:e3161e15df7fbec61dd7cff9bda850bfb1968e0427b00020d606498becac8b83,hydradb:hydra-user:05fe1b59581e7cb67ee4bf4a83c722cbe6b0b7015cb2fa751bfebcc8fc6045c8"
```