### PR TITLE
chore: cloud-init: v1.2.2

### DIFF
--- a/systemd/configs/openchami.env
+++ b/systemd/configs/openchami.env
@@ -49,7 +49,8 @@ HSM_URL=http://smd:27779
 ANSIBLE_HOST_KEY_CHECKING=False
 
 # Environemnt Variables for cloud-init
-LISTEN_ADDR=:27777
+LISTEN=:27777
 SMD_URL=http://smd:27779
 OPAAL_URL=http://opaal:3333
 JWKS_URL=http://opaal:3333/keys
+IMPERSONATION=true

--- a/systemd/containers/cloud-init-server.container
+++ b/systemd/containers/cloud-init-server.container
@@ -7,7 +7,7 @@ PartOf=openchami.target
 [Container]
 ContainerName=cloud-init-server
 HostName=cloud-init
-Image=ghcr.io/openchami/cloud-init:v1.2.1
+Image=ghcr.io/openchami/cloud-init:v1.2.2
 
 # Environment Variables
 EnvironmentFile=/etc/openchami/configs/openchami.env


### PR DESCRIPTION
Also, update environment variables in openchami.env. Enable impersonation out of the box so that `ochami` commands work.