### PR TITLE
chore(cloud-init): v1.2.2 -> v1.2.3

### DIFF
--- a/systemd/containers/cloud-init-server.container
+++ b/systemd/containers/cloud-init-server.container
@@ -7,7 +7,7 @@ PartOf=openchami.target
 [Container]
 ContainerName=cloud-init-server
 HostName=cloud-init
-Image=ghcr.io/openchami/cloud-init:v1.2.2
+Image=ghcr.io/openchami/cloud-init:v1.2.3
 
 # Environment Variables
 EnvironmentFile=/etc/openchami/configs/openchami.env


### PR DESCRIPTION
Incorporate YAML reflect tag fixes from https://github.com/OpenCHAMI/cloud-init/issues/78 so that 'meta-data' key works.