### PR TITLE
build(Makefile): make more robust and generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,35 @@
 .PHONY: all clean
 
+GIT     ?= $(shell command -v git 2>/dev/null)
+TAG     ?= $(shell $(GIT) describe --tags --always --abbrev=0)
+VERSION ?= $(patsubst v%,%,$(TAG))
+RELEASE ?= 1
+HOME    ?= $(shell echo ${HOME})
+
+rwildcard = $(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+
 all: openchami.rpm
 
-tarball:
-	mkdir -p ~/rpmbuild/SOURCES
-	rm -Rf ~/rpmbuild/SOURCES/openchami-0.9.0.tar.gz
-	tar czvf ~/rpmbuild/SOURCES/openchami-0.9.0.tar.gz --transform 's,^,openchami-0.9.0/,' *
+$(HOME)/rpmbuild:
+	rpmdev-setuptree
 
-openchami.rpm: openchami.spec tarball
-	rpmbuild -bb openchami.spec
+$(HOME)/rpmbuild/SPECS/openchami.spec: openchami.spec $(HOME)/rpmbuild
+	mkdir -p $(HOME)/rpmbuild/SPECS
+	cp $< $@
+
+	cp -r $< $@
+
+$(HOME)/rpmbuild/SOURCES/openchami-$(VERSION).tar.gz: $(HOME)/rpmbuild $(call rwildcard,.,*)
+	mkdir -p $(HOME)/rpmbuild/SOURCES
+	rm -Rf $(HOME)/rpmbuild/SOURCES/openchami-$(VERSION).tar.gz
+	tar czvf $@ --transform 's,^,openchami-$(VERSION)/,' *
+
+$(HOME)/rpmbuild/RPMS/noarch/openchami-$(VERSION)-$(RELEASE).noarch.rpm: $(HOME)/rpmbuild/SPECS/openchami.spec $(HOME)/rpmbuild/SOURCES/openchami-$(VERSION).tar.gz
+	rpmbuild -ba $(HOME)/rpmbuild/SPECS/openchami.spec --define 'version $(VERSION)' --define 'rel $(RELEASE)'
+
+openchami.rpm: $(HOME)/rpmbuild/RPMS/noarch/openchami-$(VERSION)-$(RELEASE).noarch.rpm
+	cp $< $@
 
 clean:
-	rm -rf ~/rpmbuild
+	rm -rf $(HOME)/rpmbuild
+	rm -f openchami.rpm


### PR DESCRIPTION
Remove hard coded paths and allow it to work on multiple versions.

To build `openchami.rpm` in the root repo directory:
```bash
make
```

It can be removed with:
```
make clean
```