### PR TITLE
feat: add openchami-cert-trust.service

### DIFF
--- a/openchami.spec
+++ b/openchami.spec
@@ -57,6 +57,7 @@ chmod 644 %{buildroot}/etc/openchami/configs/*
 /etc/systemd/system/openchami.target
 /etc/systemd/system/openchami-cert-renewal.service
 /etc/systemd/system/openchami-cert-renewal.timer
+/etc/systemd/system/openchami-cert-trust.service
 /usr/local/bin/bootstrap_openchami.sh
 /etc/profile.d/openchami.sh
 /etc/openchami/pg-init/multi-psql-db.sh

--- a/systemd/containers/acme-register.container
+++ b/systemd/containers/acme-register.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=The acme-register container
-Requires=step-ca.service 
-After=step-ca.service 
+Requires=openchami-cert-trust.service
+After=openchami-cert-trust.service
 
 [Container]
 ContainerName=demo.openchami.cluster

--- a/systemd/system/openchami-cert-trust.service
+++ b/systemd/system/openchami-cert-trust.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Extract and trust OpenCHAMI root CA certificate
+After=step-ca.service
+Requires=step-ca.service
+
+[Service]
+Type=oneshot
+ExecStart=podman cp step-ca:/root_ca/root_ca.crt /etc/pki/ca-trust/source/anchors/openchami.pem
+ExecStart=update-ca-trust
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add an intermediate oneshot service, openchami-cert-trust.service, that copies the step-ca root CA certificate from the container to the host anchors directory and trusts it. This happens _before_ acme-register and acme-deploy so that the CA cert is trusted by the system bundle before mounting it into the container to retrieve the haproxy certificate.

This eliminates the need to start the step-ca service first, separately from openchami.target. Instead, one can simply start openchami.target, have everything come up, and automatically trust the step-ca CA certificate.

Relevant dependency chart attached.

Supercedes #9.
![openchami-re-head](https://github.com/user-attachments/assets/43930a19-4820-4e63-9cc0-6d0120499cb5)
