### PR TITLE
fix: don't overwrite config files and other changes

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -125,6 +125,21 @@ jobs:
           escaped_key=$(echo "$key" | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "::set-output name=pubkey::${escaped_key}"
 
+      - name: Genereate release notes
+        if: env.VERSION != '0.0.0'
+        id: gen_rel_notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo '# OpenCHAMI v${{ env.VERSION }}'
+            echo ''
+            echo '**RPM SHA256 Checksum:**'
+            echo '`${{ steps.compute_checksum.outputs.checksum }}`'
+            echo
+            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -F tag_name="${{ steps.extract_version.outputs.version }}" --jq .body
+          } > CHANGELOG.md
+
       - name: Create GitHub Release
         if: env.VERSION != '0.0.0'
         id: create_release
@@ -136,11 +151,7 @@ jobs:
           release_name: v${{ env.VERSION }}
           draft: false
           prerelease: false
-          body: |
-            Release for openchami version v${{ env.VERSION }}
-
-            **RPM SHA256 Checksum:**
-            `${{ steps.compute_checksum.outputs.checksum }}`
+          body_path: CHANGELOG.md
 
       - name: Upload RPM to GitHub Release
         if: env.VERSION != '0.0.0'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+openchami-*.noarch.rpm

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ HOME    ?= $(shell echo ${HOME})
 
 rwildcard = $(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 
-all: openchami.rpm
+all: openchami-$(VERSION)-$(RELEASE).noarch.rpm
 
 $(HOME)/rpmbuild:
 	rpmdev-setuptree
@@ -27,9 +27,9 @@ $(HOME)/rpmbuild/SOURCES/openchami-$(VERSION).tar.gz: $(HOME)/rpmbuild $(call rw
 $(HOME)/rpmbuild/RPMS/noarch/openchami-$(VERSION)-$(RELEASE).noarch.rpm: $(HOME)/rpmbuild/SPECS/openchami.spec $(HOME)/rpmbuild/SOURCES/openchami-$(VERSION).tar.gz
 	rpmbuild -ba $(HOME)/rpmbuild/SPECS/openchami.spec --define 'version $(VERSION)' --define 'rel $(RELEASE)'
 
-openchami.rpm: $(HOME)/rpmbuild/RPMS/noarch/openchami-$(VERSION)-$(RELEASE).noarch.rpm
+openchami-$(VERSION)-$(RELEASE).noarch.rpm: $(HOME)/rpmbuild/RPMS/noarch/openchami-$(VERSION)-$(RELEASE).noarch.rpm
 	cp $< $@
 
 clean:
 	rm -rf $(HOME)/rpmbuild
-	rm -f openchami.rpm
+	rm -f openchami-*.noarch.rpm

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 OpenCHAMI is a collection of microservices that are assembled and tested to provide HPC cluster provisioning and management.  It is released quarterly.  As far as possible, each release is supported for three years from the release date.  Since some of the components in OpenCHAMI are not developed by the consortium, we cannot promise support beyond that provided by the upstream projects.  See our [Release Policy](/Release_Policy.md) for more details.
 
+## Building Locally
+
+Requirements:
+
+- `rpmdevtools`
+- `make`
+
+Generate `openchami-<version>-1.noarch.rpm` in this repo:
+
+```bash
+make
+```
+
+Increase the release version (`openchami-<version>-2.noarch.rpm`):
+
+```bash
+make RELEASE=2
+```
+
+Clean built RPMs in repo directory:
+
+```
+make clean
+```
+
 ## Current Release
 
 OpenCHAMI is in development without an initial release.  We expect a first supported release in Q1 2025.  If you would like to follow the most current, stable configuration, each of the partners maintains a deployment recipe that will become a release candidate in our [Deployment Recipes](https://github.com/OpenCHAMI/deployment-recipes) Repository.

--- a/openchami.spec
+++ b/openchami.spec
@@ -48,12 +48,9 @@ chmod +x %{buildroot}/usr/libexec/openchami/bootstrap_openchami.sh
 chmod 600 %{buildroot}/etc/openchami/configs/openchami.env
 chmod 644 %{buildroot}/etc/openchami/configs/*
 
-
-
-
 %files
 %license LICENSE
-/etc/openchami/configs/*
+%config(noreplace) /etc/openchami/configs/*
 /etc/containers/systemd/*
 /etc/systemd/system/openchami.target
 /etc/systemd/system/openchami-cert-renewal.service

--- a/systemd/configs/haproxy.cfg
+++ b/systemd/configs/haproxy.cfg
@@ -40,7 +40,6 @@ frontend openchami
   acl PATH_opaal-idp path_beg -i /oauth2/token
 
   acl PATH_cloud-init path_beg -i /cloud-init
-  acl PATH_cloud-init path_beg -i /cloud-init-secure
 
   acl PATH_configurator path_beg -i /generate
   acl PATH_configurator path_beg -i /configurator

--- a/systemd/containers/acme-deploy.container
+++ b/systemd/containers/acme-deploy.container
@@ -33,4 +33,4 @@ Exec=--deploy \
 [Service]
 Restart=on-failure
 Type=oneshot
-RemainAfterExit=no
+RemainAfterExit=yes

--- a/systemd/containers/acme-deploy.container
+++ b/systemd/containers/acme-deploy.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=The acme-deploy container
-Requires=acme-register.service acme-certs.volume
-After=acme-register.service acme-certs.volume
+Requires=haproxy-certs-volume.service acme-register.service
+After=haproxy-certs-volume.service acme-register.service
 
 [Container]
 ContainerName=acme-deploy

--- a/systemd/containers/acme-deploy.container
+++ b/systemd/containers/acme-deploy.container
@@ -2,6 +2,7 @@
 Description=The acme-deploy container
 Requires=haproxy-certs-volume.service acme-register.service
 After=haproxy-certs-volume.service acme-register.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=acme-deploy

--- a/systemd/containers/acme-register.container
+++ b/systemd/containers/acme-register.container
@@ -2,6 +2,7 @@
 Description=The acme-register container
 Requires=acme-certs-volume.service openchami-cert-trust.service acme-certs-volume.service
 After=acme-certs-volume.service openchami-cert-trust.service acme-certs-volume.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=demo.openchami.cluster

--- a/systemd/containers/acme-register.container
+++ b/systemd/containers/acme-register.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=The acme-register container
-Requires=openchami-cert-trust.service
-After=openchami-cert-trust.service
+Requires=acme-certs-volume.service openchami-cert-trust.service acme-certs-volume.service
+After=acme-certs-volume.service openchami-cert-trust.service acme-certs-volume.service
 
 [Container]
 ContainerName=demo.openchami.cluster

--- a/systemd/containers/bss-init.container
+++ b/systemd/containers/bss-init.container
@@ -2,6 +2,7 @@
 Description=The bss-init container
 Wants=smd.service 
 Requires=postgres.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=bss-init

--- a/systemd/containers/haproxy.container
+++ b/systemd/containers/haproxy.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=The haproxy container
 Wants=bss.service cloud-init-server.service smd.service acme-deploy.service
-After=opaal.service smd.service bss.service acme-deploy.service cloud-init-server.service
-Requires=acme-deploy.service
+After=openchami-external-network.service opaal.service smd.service bss.service acme-deploy.service cloud-init-server.service
+Requires=openchami-external-network.service acme-deploy.service
 PartOf=openchami.target
 
 [Container]

--- a/systemd/containers/hydra-gen-jwks.container
+++ b/systemd/containers/hydra-gen-jwks.container
@@ -23,4 +23,4 @@ PodmanArgs=--http-proxy=false
 [Service]
 Restart=on-failure
 Type=oneshot
-RemainAfterExit=no
+RemainAfterExit=yes

--- a/systemd/containers/hydra-gen-jwks.container
+++ b/systemd/containers/hydra-gen-jwks.container
@@ -2,6 +2,7 @@
 Description=The hydra-gen-jwks container
 Wants=hydra.service
 After=hydra.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=hydra-gen-jwks

--- a/systemd/containers/hydra-migrate.container
+++ b/systemd/containers/hydra-migrate.container
@@ -2,6 +2,7 @@
 Description=The hydra-migrate container
 Requires=postgres.service
 After=postgres.service
+PartOf=openchami.target
 
 [Container]
 ContainerName=hydra-migrate

--- a/systemd/containers/hydra-migrate.container
+++ b/systemd/containers/hydra-migrate.container
@@ -29,4 +29,4 @@ PodmanArgs=--http-proxy=false
 [Service]
 Restart=on-failure
 Type=oneshot
-RemainAfterExit=no
+RemainAfterExit=yes

--- a/systemd/containers/postgres.container
+++ b/systemd/containers/postgres.container
@@ -1,6 +1,8 @@
 [Unit]
 Description=The postgres container
 PartOf=openchami.target
+Requires=openchami-internal.network openchami-jwt-internal.network postgres-data-volume.service
+After=openchami-internal.network openchami-jwt-internal.network postgres-data-volume.service
 
 [Container]
 ContainerName=postgres

--- a/systemd/containers/step-ca.container
+++ b/systemd/containers/step-ca.container
@@ -1,6 +1,8 @@
 [Unit]
 Description=The step-ca container
 PartOf=openchami.target
+Requires=openchami-cert-internal-network.service step-ca-home-volume.service step-ca-db-volume.service step-root-ca-volume.service
+After=openchami-cert-internal-network.service step-ca-home-volume.service step-ca-db-volume.service step-root-ca-volume.service
 
 [Container]
 ContainerName=step-ca

--- a/systemd/system/openchami-cert-trust.service
+++ b/systemd/system/openchami-cert-trust.service
@@ -2,6 +2,7 @@
 Description=Extract and trust OpenCHAMI root CA certificate
 After=step-ca.service
 Requires=step-ca.service
+PartOf=openchami.target
 
 [Service]
 Type=oneshot

--- a/systemd/system/openchami-cert-trust.service
+++ b/systemd/system/openchami-cert-trust.service
@@ -6,7 +6,7 @@ PartOf=openchami.target
 
 [Service]
 Type=oneshot
-ExecStart=podman cp step-ca:/root_ca/root_ca.crt /etc/pki/ca-trust/source/anchors/openchami.pem
+ExecStart=/bin/sh -c 'until podman cp step-ca:/root_ca/root_ca.crt /etc/pki/ca-trust/source/anchors/openchami.pem; do sleep 1; done'
 ExecStart=update-ca-trust
 StandardOutput=journal
 RemainAfterExit=yes

--- a/systemd/system/openchami-cert-trust.service
+++ b/systemd/system/openchami-cert-trust.service
@@ -9,6 +9,7 @@ Type=oneshot
 ExecStart=podman cp step-ca:/root_ca/root_ca.crt /etc/pki/ca-trust/source/anchors/openchami.pem
 ExecStart=update-ca-trust
 StandardOutput=journal
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/volumes/local-certs.volume
+++ b/systemd/volumes/local-certs.volume
@@ -1,5 +1,0 @@
-[Unit]
-Description=local-certs Volume
-
-[Volume]
-VolumeName=local-certs


### PR DESCRIPTION
## Fixes

- **Mark `/etc/openchami/configs/` as config files in the spec file.** This makes updates to these files get installed as `.rpmnew` files, and will move any modified versions to `.rpmsave` files during uninstallation.
- **Replace `.volume` and `.network` Systemd dependencies with `.service` ones.** `.volume` and `.network` extensions are Podman quadlet extensions that are not recognized by Systemd. Instead, the Podman generator creates `-volume.service` and `-network.service` files, respectively. Use this in the Systemd unit files instead.
- **Add oneshot services to `openchami.target`.** It's difficult to troubleshoot issues which oneshot services (e.g. `acme-register.service`, etc.) have failed if they don't appear in the output of `systemctl list-dependencies openchami.target`. Add them so that they appear, and so that they are stopped when the target is stopped.
  - **Set `RemainAfterExit=yes` for oneshot services.** This is so they appear as successful in the list-dependencies output (green dot) when successful instead of an empty circle (looking like it wasn't started).
- **Make `openchami-cert-trust.service` wait for `step-ca.service` before pulling certs.** `openchami-cert-trust.service` would fail if `step-ca.service` did not place the certs file, creating a race condition. Add an `until` loop to the former so that it waits for the latter to place the file.

## Chores

- **Remove unused `local-certs.volume`.** This wasn't being used by anything.
- **Add build instructions to README.**
- **Remove lingering `/cloud-init-secure` route in haproxy config.** cloud-init no longer uses this route.

## Build/CI

- **Use GitHub API to generate release notes.** Similar to [image-builder](https://github.com/OpenCHAMI/image-builder/blob/c564960e343cd8abef71ba6b6ac456f5e273ea1d/.github/workflows/build.yaml#L68-L84), use the GitHub API to generate release notes with bulleted changes and add them to the release template.
- **Add version string to RPM generated by Makefile.**