### PR TITLE
fix: Opaal not included in bootstrap or cert update

### DIFF
--- a/scripts/bootstrap_openchami.sh
+++ b/scripts/bootstrap_openchami.sh
@@ -28,6 +28,7 @@ generate_environment_file() {
   local short_name=$(hostname -s)
   local dns_name=$(hostname -d)
   local system_fqdn=$(hostname)
+
   sed -i "s/^SYSTEM_NAME=.*/SYSTEM_NAME=${short_name}/" /etc/openchami/configs/openchami.env
   sed -i "s/^SYSTEM_DOMAIN=.*/SYSTEM_DOMAIN=${dns_name}/" /etc/openchami/configs/openchami.env
   sed -i "s/^SYSTEM_URL=.*/SYSTEM_URL=${system_fqdn}/" /etc/openchami/configs/openchami.env
@@ -40,10 +41,12 @@ generate_environment_file() {
 
 acme_correction() {
   local system_fqdn=$(hostname)
+  primary_ip=$(hostname -I | awk '{print $1}')
   sed -i "s|-d .* \\\\|-d ${system_fqdn} \\\\|" /etc/containers/systemd/acme-deploy.container
   sed -i "s/^ContainerName=.*/ContainerName=${system_fqdn}/" /etc/containers/systemd/acme-register.container
   sed -i "s/^HostName=.*/HostName=${system_fqdn}/" /etc/containers/systemd/acme-register.container
   sed -i "s|-d .* \\\\|-d ${system_fqdn} \\\\|" /etc/containers/systemd/acme-register.container
+  sed -i "s|--add-host='demo\.openchami\.cluster:[0-9\.]*'|--add-host='${system_fqdn}:${primary_ip}'|" /etc/openchami/configs/opaal.container
 }
 
 # Check and create secrets with random passwords if needed

--- a/scripts/openchami-certificate-update
+++ b/scripts/openchami-certificate-update
@@ -4,6 +4,7 @@ update_dns() {
     local system_fqdn=$1
     local short_name="${system_fqdn%%.*}" 
     local dns_name="${system_fqdn#*.}"
+    local primary_ip=$(hostname -I | awk '{print $1}')
     
     # Update names in environment and acme containers
     sed -i "s/^SYSTEM_NAME=.*/SYSTEM_NAME=${short_name}/" /etc/openchami/configs/openchami.env
@@ -18,6 +19,10 @@ update_dns() {
     sed -i "s/^ContainerName=.*/ContainerName=${system_fqdn}/" /etc/containers/systemd/acme-register.container
     sed -i "s/^HostName=.*/HostName=${system_fqdn}/" /etc/containers/systemd/acme-register.container
     sed -i "s|-d .* \\\\|-d ${system_fqdn} \\\\|" /etc/containers/systemd/acme-register.container
+    sed -i "s|--add-host='demo\.openchami\.cluster:[0-9\.]*'|--add-host='${system_fqdn}:${primary_ip}'|" /etc/openchami/configs/opaal.container
+
+    # Reload systemD after .container changes
+    systemctl daemon-reload
 
     # Re-apply Certificates
     systemctl restart acme-deploy


### PR DESCRIPTION
Opaal was not included in the certificate update, there is a place where opaal is used and needs the update FQDN and IP