### PR TITLE
feat: add CoreDNS

### DIFF
--- a/openchami.spec
+++ b/openchami.spec
@@ -71,6 +71,12 @@ chmod 644 %{buildroot}/etc/openchami/configs/*
 /etc/openchami/pg-init/multi-psql-db.sh
 /usr/bin/openchami-certificate-update
 
+%pre
+if [ -f /etc/containers/systemd/coresmd.container ]; then
+	echo 'WARNING: /etc/containers/systemd/coresmd.container as been replaced by /etc/containers/systemd/coresmd-coredhcp.container.'
+	echo '         Migrate to coresmd-coredhcp to avoid any issues.'
+fi
+
 %post
 # reload systemd so new units are seen
 systemctl daemon-reload

--- a/systemd/configs/Corefile
+++ b/systemd/configs/Corefile
@@ -1,0 +1,41 @@
+.:53 {
+    # Enable readiness endpoint.
+    #ready
+
+    # Bind Prometheus metrics endpoint.
+    prometheus 0.0.0.0:9153
+
+    # Bind to specific IP address.
+    #bind 172.16.0.254
+
+    # Specify DNS forwarders.
+    #forward . 8.8.8.8
+
+    # Generate DNS records based on BMC and node data in SMD.
+    coresmd {
+        # Base URI of OpenCHAMI cluster. The SMD base endpoint is appended to this
+        # when requesting node and BMC data from SMD.
+        #smd_url https://demo.openchami.cluster:8443
+
+        # Path to CA certificate bundle to use when verifying TLS for smd_url.
+        #ca_cert /root_ca/root_ca.crt
+
+        # Frequency to update the SMD data cache.
+        cache_duration 30s
+
+        # DNS zone configurations based on records generated from SMD data.
+        #zone openchami.cluster {
+        #    # Besides generating DNS records for nodes based on xname, a custom
+        #    # record format can be specified based on the node ID. For instance:
+        #    #
+        #    # nodes de{03d}
+        #    #
+        #    # will produce:
+        #    #
+        #    # de001.openchami.cluster
+        #    #
+        #    # for node ID 1 and domain openchami.cluster.
+        #    nodes de{03d}
+        #}
+    }
+}

--- a/systemd/containers/coresmd-coredhcp.container
+++ b/systemd/containers/coresmd-coredhcp.container
@@ -1,16 +1,16 @@
 [Unit]
-Description=The coresmd container
+Description=The CoreSMD CoreDHCP container
 Wants=haproxy.service
 After=haproxy.service
 PartOf=openchami.target
 
 [Container]
-ContainerName=coresmd
+ContainerName=coresmd-coredhcp
 
-HostName=coresmd
-Image=ghcr.io/openchami/coredhcp:v0.3.0
+HostName=coresmd-coredhcp
+Image=ghcr.io/openchami/coresmd:v0.4.0
 
-#Capabilities
+# Capabilities
 AddCapability=NET_ADMIN
 AddCapability=NET_RAW
 

--- a/systemd/containers/coresmd-coredns.container
+++ b/systemd/containers/coresmd-coredns.container
@@ -1,0 +1,31 @@
+[Unit]
+Description=The CoreSMD CoreDNS container
+Wants=haproxy.service
+After=haproxy.service
+PartOf=openchami.target
+
+[Container]
+ContainerName=coresmd-coredns
+
+HostName=coresmd-coredns
+Image=ghcr.io/openchami/coresmd:v0.4.0
+
+Exec=/coredns
+
+# Capabilities
+AddCapability=NET_ADMIN
+AddCapability=NET_RAW
+
+# Volumes
+Volume=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/root_ca/root_ca.crt:ro,Z
+Volume=/etc/openchami/configs/Corefile:/Corefile
+
+# Networks for the Container to use
+Network=host
+
+# Unsupported by generator options
+# Proxy settings
+PodmanArgs=--http-proxy=false
+
+[Service]
+Restart=always

--- a/systemd/targets/openchami.target
+++ b/systemd/targets/openchami.target
@@ -1,4 +1,5 @@
 [Unit]
 Description=Group of OpenCHAMI-related services
 Requires=bss.service smd.service opaal.service cloud-init-server.service coresmd-coredhcp.service step-ca.service haproxy.service
-After=bss-init.service smd-init.service postgres.service
+Wants=coresmd-coredns.service
+After=bss-init.service smd-init.service postgres.service coresmd-coredns.service

--- a/systemd/targets/openchami.target
+++ b/systemd/targets/openchami.target
@@ -1,4 +1,4 @@
 [Unit]
 Description=Group of OpenCHAMI-related services
-Requires=bss.service smd.service opaal.service cloud-init-server.service coresmd.service step-ca.service haproxy.service
+Requires=bss.service smd.service opaal.service cloud-init-server.service coresmd-coredhcp.service step-ca.service haproxy.service
 After=bss-init.service smd-init.service postgres.service


### PR DESCRIPTION
With the merge of https://github.com/OpenCHAMI/coresmd/pull/26, this PR updates the CoreSMD (CoreDHCP) image to v0.4.0 and adds a CoreDNS quadlet, also using v0.4.0 of CoreSMD.

## Changes

- Change `coresmd` quadlet name to `coresmd-coredhcp` (to distinguish it from CoreDNS)
  - Add warning message about removing old `coresmd` quadlet if it exists on the filesystem when package is installed
- Add `coresmd-coredns` quadlet and example config at **/etc/openchami/configs/Corefile**

## Testing

1. Build/Install RPM.
2. `systemctl list-dependencies openchami.target` and observe that `coresmd-coredns.service` is present and not started.
3. `sudo systemctl stop coresmd` if it is running. Make sure machine CoreDNS will run on is configured as a DNS server in **/etc/openchami/configs/coredhcp.yaml**.
4. Customize **/etc/openchami/configs/Corefile** (see [README](https://github.com/OpenCHAMI/coresmd/blob/main/coredns/README.md) for guidance).
5. `sudo systemctl start coresmd-coredns`
6. Use `ping`/`dig`/etc. to test.