### PR TITLE
feat: add persistence to cloud-init

### DIFF
--- a/systemd/configs/haproxy.cfg
+++ b/systemd/configs/haproxy.cfg
@@ -66,6 +66,7 @@ backend bss
 
 backend cloud-init
   server cloud-init-server cloud-init-server:27777
+  http-request replace-path ^/cloud-init(/.*) \1
 
 backend configurator
   server configurator configurator:3334 init-addr none

--- a/systemd/containers/cloud-init-server.container
+++ b/systemd/containers/cloud-init-server.container
@@ -7,7 +7,9 @@ PartOf=openchami.target
 [Container]
 ContainerName=cloud-init-server
 HostName=cloud-init
-Image=ghcr.io/openchami/cloud-init:v1.2.3
+Image=ghcr.io/openchami/cloud-init:v1.3.0
+
+Volume=cloud-init-data:/cloud-init:rw,Z
 
 # Environment Variables
 EnvironmentFile=/etc/openchami/configs/openchami.env

--- a/systemd/volumes/cloud-init-data.volume
+++ b/systemd/volumes/cloud-init-data.volume
@@ -1,0 +1,5 @@
+[Unit]
+Description=cloud-init-server Data Volume
+
+[Volume]
+VolumeName=cloud-init-data


### PR DESCRIPTION
Closes #35 

- Add cloud-init-data Podman volume, mount into quadlet
- Update haproxy config: change endpoint mount: /cloud-init -> /

Once the cloud-init version gets bumped, we can update it here before merging.