### PR TITLE
Add :ro,Z to coresmd-coredns.container Corefile volume spec

### DIFF
--- a/systemd/containers/coresmd-coredns.container
+++ b/systemd/containers/coresmd-coredns.container
@@ -18,7 +18,7 @@ AddCapability=NET_RAW
 
 # Volumes
 Volume=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/root_ca/root_ca.crt:ro,Z
-Volume=/etc/openchami/configs/Corefile:/Corefile
+Volume=/etc/openchami/configs/Corefile:/Corefile:ro,Z
 
 # Networks for the Container to use
 Network=host


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [N/A] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

This PR adds the `:ro,Z` options to the volume spec for `Corefile` in the `coresmd-coredns` container file for systemd. Without these options, `coresmd-coredns` may fail to read the `Corefile` on systems where SELinux is enabled. This happened to me while developing OpenCHAMI on vTDS and caused me to have to work around it by patching the container file. With the options, `coresmd-coredns` has read-only access to `Corefile` and can read in its configuration.

This was tested on vTDS and worked correctly. The container file without this change did not work.

Fixes #39 

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
