### PR TITLE
Enhance GPG key reporting for import step in build workflow

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Import GPG key
         run: |
           echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import --batch --yes
+          gpg -K --keyid-format long
+          gpg --list-secret-keys --with-subkey-fingerprints --keyid-format long
+          gpg --list-secret-keys --with-colons
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 


### PR DESCRIPTION
This pull request adds additional GPG key listing commands to the RPM build workflow to improve visibility and debugging of imported GPG keys.

Improvements to GPG key management in the build workflow:

* Added commands to display imported GPG secret keys in various formats after import, making it easier to verify and debug GPG key issues in the GitHub Actions workflow (`.github/workflows/build-rpm.yaml`).

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
