### PR TITLE
ci: tell gpg which key to sign with

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -74,6 +74,7 @@ jobs:
         run: |
           echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
             --armor --detach-sign \
+            --local-user admin@openchami.org \
             --output ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}.tar.gz.asc \
             ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}.tar.gz
         env:


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [ ] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Attempt to fix "gpg: signing failed: No secret key" error by specifying which key to use for signing (namely, the one that was imported).

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
