### PR TITLE
refactor: streamline ephemeral GPG key generation and signing process

### DIFF
--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -80,18 +80,17 @@ jobs:
 
       - name: Sign source tarball
         env:
-          GPG_SIGNING_KEYID: ${{ steps.ephemeral.outputs.ephemeral-keyid }}
           GPG_SIGNING_FINGERPRINT: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
         run: |
           set -euo pipefail
           unset GPG_TTY
-          echo "Signing source tarball with key: ${GPG_SIGNING_KEYID} (${GPG_SIGNING_FINGERPRINT})"
+          echo "Signing source tarball with key: ${GPG_SIGNING_FINGERPRINT}"
           gpg --batch --list-secret-keys --keyid-format LONG "${GPG_SIGNING_FINGERPRINT}"
           gpg --batch --yes \
             --no-tty --pinentry-mode loopback \
             --status-fd 2 \
             --armor --detach-sign \
-            --local-user "${GPG_SIGNING_KEYID}" \
+            --local-user "${GPG_SIGNING_FINGERPRINT}" \
             --output ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz.asc \
             ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz
   
@@ -104,13 +103,13 @@ jobs:
       - name: Sign RPM packages
         shell: bash
         env:
-          GPG_SIGNING_KEYID: ${{ steps.ephemeral.outputs.ephemeral-keyid }}
           GPG_SIGNING_FINGERPRINT: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
         run: |
           set -euo pipefail
           unset GPG_TTY
-          echo "Using RPM signing key: ${GPG_SIGNING_KEYID} (${GPG_SIGNING_FINGERPRINT})"
+          echo "Using RPM signing key: ${GPG_SIGNING_FINGERPRINT}"
           gpg --batch --list-secret-keys --keyid-format LONG "${GPG_SIGNING_FINGERPRINT}"
+          sed -i '/^%__gpg_sign_cmd/d' ~/.rpmmacros
           echo 'Configured ~/.rpmmacros:'
           cat ~/.rpmmacros
 
@@ -118,7 +117,7 @@ jobs:
           while IFS= read -r -d '' rpm_file; do
             found=1
             echo "Signing RPM: $rpm_file"
-            rpmsign --key-id "${GPG_SIGNING_KEYID}" --addsign "$rpm_file"
+            rpmsign --key-id "${GPG_SIGNING_FINGERPRINT}" --addsign "$rpm_file"
           done < <(find ~/rpmbuild/RPMS/ -type f -name "*.rpm" -print0)
 
           if [ "$found" -eq 0 ]; then

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -57,7 +57,6 @@ jobs:
           else
             VERSION=0.0.0
           fi
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version is ${VERSION}"
 
@@ -69,10 +68,10 @@ jobs:
 
       - name: Create source tarball
         run: |
-          mkdir -p ~/rpmbuild/SOURCES/openchami-${VERSION}
-          cp -r ./* ~/rpmbuild/SOURCES/openchami-${VERSION}/
-          tar -czf ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz \
-            -C ~/rpmbuild/SOURCES openchami-${VERSION}
+          mkdir -p ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}
+          cp -r ./* ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}/
+          tar -czf ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz \
+            -C ~/rpmbuild/SOURCES openchami-${{ steps.get_version.outputs.version }}
 
       - name: Sign source tarball
         env:
@@ -87,13 +86,13 @@ jobs:
             --no-tty --pinentry-mode loopback \
             --armor --detach-sign \
             --local-user "${GPG_SIGNING_KEYID}" \
-            --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
-            ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz
+            --output ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz.asc \
+            ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz
   
       - name: Build RPM package
         run: |
           rpmbuild -ba ~/rpmbuild/SPECS/*.spec \
-            --define "version $VERSION" \
+            --define "version ${{ steps.get_version.outputs.version }}" \
             --define "rel 1"
 
       - name: Sign RPM packages

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -34,39 +34,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Import repo signing key
-        run: |
-          printf '%s' '${{ secrets.GPG_SUBKEY_B64 }}' | base64 --decode > repo-signing-subkey.asc
-          gpg --batch --import repo-signing-subkey.asc
+      - name: Check signing subkey expiration
+        uses: OpenCHAMI/gpg-signing-manager/actions/check-subkey-expiration@main
+        with:
+          subkey-armored-b64: ${{ secrets.GPG_SUBKEY_B64 }}
+          warn-days: '30'
 
-      - name: Discover repo signing key
+      - name: Setup RPM signing
         id: repo_key
-        shell: bash
-        run: |
-          keyid=$(gpg --list-secret-keys --with-colons | awk -F: '($1=="sec" || $1=="ssb") && index($12, "s") { print $5; exit }')
-          if [ -z "$keyid" ]; then
-            echo 'Could not find imported signing-capable secret key' >&2
-            exit 1
-          fi
-
-          fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: -v keyid="$keyid" '
-            ($1=="sec" || $1=="ssb") && $5==keyid { capture=1; next }
-            capture && $1=="fpr" { print $10; exit }
-          ')
-          if [ -z "$fingerprint" ]; then
-            echo 'Could not determine imported signing key fingerprint' >&2
-            exit 1
-          fi
-
-          echo "keyid=${keyid}" >> "$GITHUB_OUTPUT"
-          echo "fingerprint=${fingerprint}" >> "$GITHUB_OUTPUT"
+        uses: OpenCHAMI/gpg-signing-manager/actions/setup-rpm-signing@main
+        with:
+          subkey-armored-b64: ${{ secrets.GPG_SUBKEY_B64 }}
+          public-key-output: public_gpg_key.asc
 
       - name: Show signing subkey expiration
         shell: bash
         run: |
           gpg --list-secret-keys --with-colons \
           | awk -F: '
-            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.repo_key.outputs.keyid }}" {
+            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.repo_key.outputs.repo-signing-keyid }}" {
               keyid = $5
               expires = $7
               if (expires == "" || expires == "0") {
@@ -94,31 +80,6 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version is ${VERSION}"
 
-      - name: Export repo public key
-        shell: bash
-        run: |
-          gpg --armor --export '${{ steps.repo_key.outputs.fingerprint }}' > public_gpg_key.asc
-
-      - name: Configure RPM signing
-        shell: bash
-        run: |
-          cat > ~/.rpmmacros <<EOF
-          %_signature gpg
-          %_openpgp_sign gpg
-          %_openpgp_sign_id ${{ steps.repo_key.outputs.fingerprint }}
-          %_gpg_path %{getenv:HOME}/.gnupg
-          %_gpg_name ${{ steps.repo_key.outputs.fingerprint }}
-          %_gpgbin /usr/bin/gpg
-          %__gpg /usr/bin/gpg
-          %_gpg_digest_algo sha256
-          %__gpg_sign_cmd %{_gpgbin} \
-              --batch --yes --no-tty --pinentry-mode loopback --no-armor \
-              %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
-              --local-user "%{_openpgp_sign_id}" \
-              --detach-sign --output %{__signature_filename} %{__plaintext_filename}
-          EOF
-          gpgconf --kill gpg-agent || true
-
       - name: Setup RPM build environment
         run: |
           rpmdev-setuptree
@@ -138,7 +99,7 @@ jobs:
           gpg --batch --yes \
             --no-tty --pinentry-mode loopback \
             --armor --detach-sign \
-            --local-user '${{ steps.repo_key.outputs.keyid }}' \
+            --local-user '${{ steps.repo_key.outputs.repo-signing-keyid }}' \
             --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
             ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz
   
@@ -151,11 +112,17 @@ jobs:
       - name: Sign RPM packages
         shell: bash
         run: |
+          set -euo pipefail
           unset GPG_TTY
+          echo "Using RPM signing fingerprint: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}"
+          echo 'Configured ~/.rpmmacros:'
+          cat ~/.rpmmacros
+
           found=0
           while IFS= read -r -d '' rpm_file; do
             found=1
-            rpmsign --key-id '${{ steps.repo_key.outputs.fingerprint }}' --addsign "$rpm_file"
+            echo "Signing RPM: $rpm_file"
+            rpmsign --key-id '${{ steps.repo_key.outputs.repo-signing-fingerprint }}' --addsign "$rpm_file"
           done < <(find ~/rpmbuild/RPMS/ -type f -name "*.rpm" -print0)
 
           if [ "$found" -eq 0 ]; then

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -23,6 +23,10 @@ jobs:
       image: fedora:latest
     env:
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+      EPHEMERAL_KEY_NAME: OpenCHAMI RPM Build
+      EPHEMERAL_KEY_COMMENT: GitHub Actions ephemeral signing key
+      EPHEMERAL_KEY_EMAIL: ci+${{ github.run_id }}@build.local
+      EPHEMERAL_KEY_EXPIRE: 1d
 
     steps:
       - name: Install dependencies
@@ -34,18 +38,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Import GPG key
-        run: |
-          echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --import --batch --yes
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          
+      - name: Generate and sign ephemeral key
+        id: ephemeral_key
+        uses: OpenCHAMI/gpg-signing-manager/actions/gpg-ephemeral-key@main
+        with:
+          subkey-armored: ${{ secrets.GPG_SUBKEY_B64 }}
+          name: ${{ env.EPHEMERAL_KEY_NAME }}
+          comment: ${{ env.EPHEMERAL_KEY_COMMENT }}
+          email: ${{ env.EPHEMERAL_KEY_EMAIL }}
+          expire: ${{ env.EPHEMERAL_KEY_EXPIRE }}
+
       - name: Show signing subkey expiration
         shell: bash
         run: |
           gpg --list-secret-keys --with-colons \
           | awk -F: '
-            $1=="ssb" && $12 ~ /s/ {
+            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.ephemeral_key.outputs.repo-signing-keyid }}" {
               keyid = $5
               expires = $7
               if (expires == "" || expires == "0") {
@@ -70,7 +78,13 @@ jobs:
             VERSION=0.0.0
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version is ${VERSION}"
+
+      - name: Export ephemeral public key
+        shell: bash
+        run: |
+          printf '%s' '${{ steps.ephemeral_key.outputs.ephemeral-public-key }}' | base64 --decode > public_gpg_key.asc
 
       - name: Setup RPM build environment
         run: |
@@ -80,109 +94,92 @@ jobs:
 
       - name: Create source tarball
         run: |
-          mkdir -p ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}
-          cp -r ./* ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}/
-          tar -czf ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}.tar.gz \
-            -C ~/rpmbuild/SOURCES openchami-${{ env.VERSION }} \
-            --transform "s|openchami-${{ env.VERSION }}-${{ env.COMMIT_SHA }}|openchami-${{ env.VERSION }}|"
+          mkdir -p ~/rpmbuild/SOURCES/openchami-${VERSION}
+          cp -r ./* ~/rpmbuild/SOURCES/openchami-${VERSION}/
+          tar -czf ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz \
+            -C ~/rpmbuild/SOURCES openchami-${VERSION}
 
       - name: Sign source tarball
         run: |
-          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+          gpg --batch --yes \
             --armor --detach-sign \
-            --local-user admin@openchami.org \
-            --output ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}.tar.gz.asc \
-            ~/rpmbuild/SOURCES/openchami-${{ env.VERSION }}.tar.gz
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+            --local-user '${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}' \
+            --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
+            ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz
   
       - name: Build RPM package
         run: |
           rpmbuild -ba ~/rpmbuild/SPECS/*.spec \
-            --define "version ${{ env.VERSION }}" \
+            --define "version $VERSION" \
             --define "rel 1"
 
       - name: Sign RPM packages
         run: |
           for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
-            echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback \
+            gpg --batch --yes \
+              --local-user '${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}' \
               --detach-sign --armor "$rpm"
-            rpm --define "_gpg_name admin@openchami.org" --addsign "$rpm"
+            rpm --define "_gpg_name ${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}" --addsign "$rpm"
           done
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Find RPM file
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         id: find_rpm
         run: |
           rpm_file=$(ls ~/rpmbuild/RPMS/noarch/*.rpm)
           echo "rpm_file=${rpm_file}" >> $GITHUB_ENV
-          echo "::set-output name=path::${rpm_file}"
+          echo "path=${rpm_file}" >> "$GITHUB_OUTPUT"
 
       - name: Compute RPM Checksum
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         id: compute_checksum
         run: |
           rpm_file=$(ls ~/rpmbuild/RPMS/noarch/*.rpm)
           checksum=$(sha256sum "$rpm_file" | awk '{print $1}')
           echo "checksum=${checksum}" >> $GITHUB_ENV
-          echo "::set-output name=checksum::${checksum}"
-      
-      - name: Export Public GPG Key
-        if: env.VERSION != '0.0.0'
-        run: |
-          gpg --armor --export admin@openchami.org > public_gpg_key.asc
-
-      - name: Get Public GPG Key Content
-        if: env.VERSION != '0.0.0'
-        id: get_pubkey
-        run: |
-          key=$(cat public_gpg_key.asc)
-          escaped_key=$(echo "$key" | sed ':a;N;$!ba;s/\n/\\n/g')
-          echo "::set-output name=pubkey::${escaped_key}"
+          echo "checksum=${checksum}" >> "$GITHUB_OUTPUT"
 
       - name: Genereate release notes
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         id: gen_rel_notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           {
-            echo '# OpenCHAMI v${{ env.VERSION }}'
+            echo '# OpenCHAMI v${{ steps.get_version.outputs.version }}'
             echo ''
             echo '**RPM SHA256 Checksum:**'
             echo '`${{ steps.compute_checksum.outputs.checksum }}`'
             echo ''
-            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -F tag_name='v${{ env.VERSION }}' --jq .body
+            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -F tag_name='v${{ steps.get_version.outputs.version }}' --jq .body
           } > CHANGELOG.md
 
       - name: Create GitHub Release
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ env.VERSION }}
-          release_name: v${{ env.VERSION }}
+          tag_name: v${{ steps.get_version.outputs.version }}
+          release_name: v${{ steps.get_version.outputs.version }}
           draft: false
           prerelease: false
           body_path: CHANGELOG.md
 
       - name: Upload RPM to GitHub Release
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ${{ steps.find_rpm.outputs.path }}
-          asset_name: openchami-${{ env.VERSION }}.rpm
+          asset_name: openchami-${{ steps.get_version.outputs.version }}.rpm
           asset_content_type: application/x-rpm
 
       - name: Upload Public GPG Key to GitHub Release
-        if: env.VERSION != '0.0.0'
+        if: steps.get_version.outputs.version != '0.0.0'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -104,15 +104,20 @@ jobs:
         run: |
           cat > ~/.rpmmacros <<EOF
           %_signature gpg
+          %_openpgp_sign gpg
+          %_openpgp_sign_id ${{ steps.repo_key.outputs.fingerprint }}
           %_gpg_path %{getenv:HOME}/.gnupg
           %_gpg_name ${{ steps.repo_key.outputs.fingerprint }}
           %_gpgbin /usr/bin/gpg
+          %__gpg /usr/bin/gpg
           %_gpg_digest_algo sha256
           %__gpg_sign_cmd %{_gpgbin} \
-              --batch --yes --pinentry-mode loopback --no-armor \
-              --local-user "%{_gpg_name}" \
+              --batch --yes --no-tty --pinentry-mode loopback --no-armor \
+              %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
+              --local-user "%{_openpgp_sign_id}" \
               --detach-sign --output %{__signature_filename} %{__plaintext_filename}
           EOF
+          gpgconf --kill gpg-agent || true
 
       - name: Setup RPM build environment
         run: |
@@ -129,7 +134,9 @@ jobs:
 
       - name: Sign source tarball
         run: |
+          unset GPG_TTY
           gpg --batch --yes \
+            --no-tty --pinentry-mode loopback \
             --armor --detach-sign \
             --local-user '${{ steps.repo_key.outputs.keyid }}' \
             --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
@@ -144,18 +151,37 @@ jobs:
       - name: Sign RPM packages
         shell: bash
         run: |
-          for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
-            rpmsign --addsign "$rpm"
-          done
+          unset GPG_TTY
+          found=0
+          while IFS= read -r -d '' rpm_file; do
+            found=1
+            rpmsign --key-id '${{ steps.repo_key.outputs.fingerprint }}' --addsign "$rpm_file"
+          done < <(find ~/rpmbuild/RPMS/ -type f -name "*.rpm" -print0)
+
+          if [ "$found" -eq 0 ]; then
+            echo 'No RPM packages were produced to sign' >&2
+            exit 1
+          fi
 
       - name: Verify RPM signatures
         shell: bash
         run: |
           found=0
-          for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
+          while IFS= read -r -d '' rpm_file; do
             found=1
-            rpm --checksig -v "$rpm"
-          done
+            output=$(rpm --checksig -v "$rpm_file" 2>&1)
+            printf '%s\n' "$output"
+
+            if printf '%s\n' "$output" | grep -q 'SIGNATURES NOT OK'; then
+              echo "RPM signature verification failed for $rpm_file" >&2
+              exit 1
+            fi
+
+            if ! printf '%s\n' "$output" | grep -Eiq 'Key ID|RSA/SHA|RSA/sha|EdDSA|pgp'; then
+              echo "RPM appears unsigned: $rpm_file" >&2
+              exit 1
+            fi
+          done < <(find ~/rpmbuild/RPMS/ -type f -name "*.rpm" -print0)
 
           if [ "$found" -eq 0 ]; then
             echo 'No RPM packages were produced to verify' >&2

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -25,7 +25,7 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
 
     steps:
-      - name: Install rpmdevtools
+      - name: Install dependencies
         shell: bash
         run: |
           if command -v sudo >/dev/null 2>&1; then
@@ -34,7 +34,7 @@ jobs:
             SUDO=
           fi
 
-          $SUDO dnf install -y rpmdevtools
+          $SUDO dnf install -y rpmdevtools gh
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -138,7 +138,10 @@ jobs:
 
       - name: Verify RPM signatures
         shell: bash
+        env:
+          GPG_SIGNING_FINGERPRINT: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
         run: |
+          rpm --import <(gpg --export --armor "${GPG_SIGNING_FINGERPRINT}")
           found=0
           while IFS= read -r -d '' rpm_file; do
             found=1

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -45,26 +45,7 @@ jobs:
         uses: OpenCHAMI/gpg-signing-manager/actions/setup-rpm-signing@main
         with:
           subkey-armored-b64: ${{ secrets.GPG_SUBKEY_B64 }}
-          public-key-output: public_gpg_key.asc
-
-      - name: Show signing subkey expiration
-        shell: bash
-        run: |
-          gpg --list-secret-keys --with-colons \
-          | awk -F: '
-            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.repo_key.outputs.repo-signing-keyid }}" {
-              keyid = $5
-              expires = $7
-              if (expires == "" || expires == "0") {
-                edate = "never"
-              } else {
-                cmd = "date -u -d @" expires " +\"%Y-%m-%d %H:%M:%S UTC\""
-                cmd | getline edate
-                close(cmd)
-              }
-              printf "signing subkey %s expires: %s\n", keyid, edate
-             }
-          '   
+          public-key-output: public_gpg_key.asc 
 
       - name: Get version
         id: get_version
@@ -94,12 +75,18 @@ jobs:
             -C ~/rpmbuild/SOURCES openchami-${VERSION}
 
       - name: Sign source tarball
+        env:
+          GPG_SIGNING_KEYID: ${{ steps.repo_key.outputs.repo-signing-keyid }}
+          GPG_SIGNING_FINGERPRINT: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}
         run: |
+          set -euo pipefail
           unset GPG_TTY
+          echo "Signing source tarball with key: ${GPG_SIGNING_KEYID} (${GPG_SIGNING_FINGERPRINT})"
+          gpg --batch --list-secret-keys --keyid-format LONG "${GPG_SIGNING_FINGERPRINT}"
           gpg --batch --yes \
             --no-tty --pinentry-mode loopback \
             --armor --detach-sign \
-            --local-user '${{ steps.repo_key.outputs.repo-signing-keyid }}' \
+            --local-user "${GPG_SIGNING_KEYID}" \
             --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
             ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz
   
@@ -111,10 +98,14 @@ jobs:
 
       - name: Sign RPM packages
         shell: bash
+        env:
+          GPG_SIGNING_KEYID: ${{ steps.repo_key.outputs.repo-signing-keyid }}
+          GPG_SIGNING_FINGERPRINT: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}
         run: |
           set -euo pipefail
           unset GPG_TTY
-          echo "Using RPM signing fingerprint: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}"
+          echo "Using RPM signing key: ${GPG_SIGNING_KEYID} (${GPG_SIGNING_FINGERPRINT})"
+          gpg --batch --list-secret-keys --keyid-format LONG "${GPG_SIGNING_FINGERPRINT}"
           echo 'Configured ~/.rpmmacros:'
           cat ~/.rpmmacros
 
@@ -122,7 +113,7 @@ jobs:
           while IFS= read -r -d '' rpm_file; do
             found=1
             echo "Signing RPM: $rpm_file"
-            rpmsign --key-id '${{ steps.repo_key.outputs.repo-signing-fingerprint }}' --addsign "$rpm_file"
+            rpmsign --key-id "${GPG_SIGNING_KEYID}" --addsign "$rpm_file"
           done < <(find ~/rpmbuild/RPMS/ -type f -name "*.rpm" -print0)
 
           if [ "$found" -eq 0 ]; then

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -23,10 +23,6 @@ jobs:
       image: fedora:latest
     env:
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
-      EPHEMERAL_KEY_NAME: OpenCHAMI RPM Build
-      EPHEMERAL_KEY_COMMENT: GitHub Actions ephemeral signing key
-      EPHEMERAL_KEY_EMAIL: ci+${{ github.run_id }}@build.local
-      EPHEMERAL_KEY_EXPIRE: 1d
 
     steps:
       - name: Install dependencies
@@ -38,22 +34,39 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Generate and sign ephemeral key
-        id: ephemeral_key
-        uses: OpenCHAMI/gpg-signing-manager/actions/gpg-ephemeral-key@main
-        with:
-          subkey-armored: ${{ secrets.GPG_SUBKEY_B64 }}
-          name: ${{ env.EPHEMERAL_KEY_NAME }}
-          comment: ${{ env.EPHEMERAL_KEY_COMMENT }}
-          email: ${{ env.EPHEMERAL_KEY_EMAIL }}
-          expire: ${{ env.EPHEMERAL_KEY_EXPIRE }}
+      - name: Import repo signing key
+        run: |
+          printf '%s' '${{ secrets.GPG_SUBKEY_B64 }}' | base64 --decode > repo-signing-subkey.asc
+          gpg --batch --import repo-signing-subkey.asc
+
+      - name: Discover repo signing key
+        id: repo_key
+        shell: bash
+        run: |
+          keyid=$(gpg --list-secret-keys --with-colons | awk -F: '($1=="sec" || $1=="ssb") && index($12, "s") { print $5; exit }')
+          if [ -z "$keyid" ]; then
+            echo 'Could not find imported signing-capable secret key' >&2
+            exit 1
+          fi
+
+          fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: -v keyid="$keyid" '
+            ($1=="sec" || $1=="ssb") && $5==keyid { capture=1; next }
+            capture && $1=="fpr" { print $10; exit }
+          ')
+          if [ -z "$fingerprint" ]; then
+            echo 'Could not determine imported signing key fingerprint' >&2
+            exit 1
+          fi
+
+          echo "keyid=${keyid}" >> "$GITHUB_OUTPUT"
+          echo "fingerprint=${fingerprint}" >> "$GITHUB_OUTPUT"
 
       - name: Show signing subkey expiration
         shell: bash
         run: |
           gpg --list-secret-keys --with-colons \
           | awk -F: '
-            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.ephemeral_key.outputs.repo-signing-keyid }}" {
+            ($1=="ssb" || $1=="sec") && $5 == "${{ steps.repo_key.outputs.keyid }}" {
               keyid = $5
               expires = $7
               if (expires == "" || expires == "0") {
@@ -81,10 +94,10 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version is ${VERSION}"
 
-      - name: Export ephemeral public key
+      - name: Export repo public key
         shell: bash
         run: |
-          printf '%s' '${{ steps.ephemeral_key.outputs.ephemeral-public-key }}' | base64 --decode > public_gpg_key.asc
+          gpg --armor --export '${{ steps.repo_key.outputs.fingerprint }}' > public_gpg_key.asc
 
       - name: Setup RPM build environment
         run: |
@@ -103,7 +116,7 @@ jobs:
         run: |
           gpg --batch --yes \
             --armor --detach-sign \
-            --local-user '${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}' \
+            --local-user '${{ steps.repo_key.outputs.keyid }}' \
             --output ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz.asc \
             ~/rpmbuild/SOURCES/openchami-${VERSION}.tar.gz
   
@@ -117,9 +130,9 @@ jobs:
         run: |
           for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
             gpg --batch --yes \
-              --local-user '${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}' \
+              --local-user '${{ steps.repo_key.outputs.keyid }}' \
               --detach-sign --armor "$rpm"
-            rpm --define "_gpg_name ${{ steps.ephemeral_key.outputs.ephemeral-fingerprint }}" --addsign "$rpm"
+            rpm --define "_gpg_name ${{ steps.repo_key.outputs.keyid }}" --addsign "$rpm"
           done
 
       - name: Find RPM file

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -25,6 +25,17 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
 
     steps:
+      - name: Install rpmdevtools
+        shell: bash
+        run: |
+          if command -v sudo >/dev/null 2>&1; then
+            SUDO=sudo
+          else
+            SUDO=
+          fi
+
+          $SUDO dnf install -y rpmdevtools
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -25,27 +25,32 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
 
     steps:
-      - name: Install dependencies
-        run: |
-          dnf install -y \
-            rpm-build rpm-sign rpmlint gcc make redhat-rpm-config \
-            gh gpg gpg2 gnupg2 expect rpmdevtools createrepo
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check signing subkey expiration
-        uses: OpenCHAMI/gpg-signing-manager/actions/check-subkey-expiration@main
+      - name: Check repo key expiration
+        uses: OpenCHAMI/gpg-signing-manager/actions/check-key-expiration@main
         with:
-          subkey-armored-b64: ${{ secrets.GPG_SUBKEY_B64 }}
-          warn-days: '30'
+          key-armored-b64: ${{ secrets.GPG_REPO_KEY_B64 }}
+          warn-days:       '30'
 
-      - name: Setup RPM signing
-        id: repo_key
+      - name: Generate ephemeral release key
+        id: ephemeral
+        uses: OpenCHAMI/gpg-signing-manager/actions/gpg-ephemeral-key@main
+        with:
+          cert-key-armored-b64: ${{ secrets.GPG_REPO_CERT_KEY_B64 }}
+          name:    '${{ github.repository }} Release'
+          comment: 'Ephemeral key for ${{ github.ref_name }}'
+          email:   'release@packages.openchami.org'
+          expire:  '1d'
+
+      - name: Setup RPM signing (ephemeral key)
+        id: rpm_signing
         uses: OpenCHAMI/gpg-signing-manager/actions/setup-rpm-signing@main
         with:
-          subkey-armored-b64: ${{ secrets.GPG_SUBKEY_B64 }}
-          public-key-output: public_gpg_key.asc 
+          repo-key-armored-b64:  ${{ secrets.GPG_REPO_KEY_B64 }}
+          ephemeral-fingerprint: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
+          public-key-output:     public_gpg_key.asc 
 
       - name: Get version
         id: get_version
@@ -75,8 +80,8 @@ jobs:
 
       - name: Sign source tarball
         env:
-          GPG_SIGNING_KEYID: ${{ steps.repo_key.outputs.repo-signing-keyid }}
-          GPG_SIGNING_FINGERPRINT: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}
+          GPG_SIGNING_KEYID: ${{ steps.ephemeral.outputs.ephemeral-keyid }}
+          GPG_SIGNING_FINGERPRINT: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
         run: |
           set -euo pipefail
           unset GPG_TTY
@@ -99,8 +104,8 @@ jobs:
       - name: Sign RPM packages
         shell: bash
         env:
-          GPG_SIGNING_KEYID: ${{ steps.repo_key.outputs.repo-signing-keyid }}
-          GPG_SIGNING_FINGERPRINT: ${{ steps.repo_key.outputs.repo-signing-fingerprint }}
+          GPG_SIGNING_KEYID: ${{ steps.ephemeral.outputs.ephemeral-keyid }}
+          GPG_SIGNING_FINGERPRINT: ${{ steps.ephemeral.outputs.ephemeral-fingerprint }}
         run: |
           set -euo pipefail
           unset GPG_TTY
@@ -145,6 +150,11 @@ jobs:
             echo 'No RPM packages were produced to verify' >&2
             exit 1
           fi
+
+      - name: Export ephemeral public key
+        run: |
+          printf '%s' '${{ steps.ephemeral.outputs.ephemeral-public-key }}' \
+            | base64 -d > ephemeral-public.asc
 
       - name: Find RPM file
         if: steps.get_version.outputs.version != '0.0.0'
@@ -202,13 +212,24 @@ jobs:
           asset_name: openchami-${{ steps.get_version.outputs.version }}.rpm
           asset_content_type: application/x-rpm
 
-      - name: Upload Public GPG Key to GitHub Release
+      - name: Upload Repo GPG Key to GitHub Release
         if: steps.get_version.outputs.version != '0.0.0'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: public_gpg_key.asc
-          asset_name: public_gpg_key.asc
+          asset_path: repo-public.asc
+          asset_name: repo_public.asc
+          asset_content_type: text/plain
+
+      - name: Upload Repo Ephemeral GPG Key to GitHub Release
+        if: steps.get_version.outputs.version != '0.0.0'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ephemeral-public.asc
+          asset_name: repo_ephemeral_public.asc
           asset_content_type: text/plain

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -99,6 +99,21 @@ jobs:
         run: |
           gpg --armor --export '${{ steps.repo_key.outputs.fingerprint }}' > public_gpg_key.asc
 
+      - name: Configure RPM signing
+        shell: bash
+        run: |
+          cat > ~/.rpmmacros <<EOF
+          %_signature gpg
+          %_gpg_path %{getenv:HOME}/.gnupg
+          %_gpg_name ${{ steps.repo_key.outputs.fingerprint }}
+          %_gpgbin /usr/bin/gpg
+          %_gpg_digest_algo sha256
+          %__gpg_sign_cmd %{_gpgbin} \
+              --batch --yes --pinentry-mode loopback --no-armor \
+              --local-user "%{_gpg_name}" \
+              --detach-sign --output %{__signature_filename} %{__plaintext_filename}
+          EOF
+
       - name: Setup RPM build environment
         run: |
           rpmdev-setuptree
@@ -127,13 +142,25 @@ jobs:
             --define "rel 1"
 
       - name: Sign RPM packages
+        shell: bash
         run: |
           for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
-            gpg --batch --yes \
-              --local-user '${{ steps.repo_key.outputs.keyid }}' \
-              --detach-sign --armor "$rpm"
-            rpm --define "_gpg_name ${{ steps.repo_key.outputs.keyid }}" --addsign "$rpm"
+            rpmsign --addsign "$rpm"
           done
+
+      - name: Verify RPM signatures
+        shell: bash
+        run: |
+          found=0
+          for rpm in $(find ~/rpmbuild/RPMS/ -type f -name "*.rpm"); do
+            found=1
+            rpm --checksig -v "$rpm"
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo 'No RPM packages were produced to verify' >&2
+            exit 1
+          fi
 
       - name: Find RPM file
         if: steps.get_version.outputs.version != '0.0.0'

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -84,6 +84,7 @@ jobs:
           gpg --batch --list-secret-keys --keyid-format LONG "${GPG_SIGNING_FINGERPRINT}"
           gpg --batch --yes \
             --no-tty --pinentry-mode loopback \
+            --status-fd 2 \
             --armor --detach-sign \
             --local-user "${GPG_SIGNING_KEYID}" \
             --output ~/rpmbuild/SOURCES/openchami-${{ steps.get_version.outputs.version }}.tar.gz.asc \

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -169,6 +169,10 @@ jobs:
           printf '%s' '${{ steps.ephemeral.outputs.ephemeral-public-key }}' \
             | base64 -d > ephemeral-public.asc
 
+      - name: Export repo public key
+        run: |
+          echo '${{ secrets.GPG_REPO_CERT_B64 }}' | base64 -d > repo-public.asc
+
       - name: Find RPM file
         if: steps.get_version.outputs.version != '0.0.0'
         id: find_rpm

--- a/.github/workflows/build-rpm.yaml
+++ b/.github/workflows/build-rpm.yaml
@@ -167,11 +167,11 @@ jobs:
       - name: Export ephemeral public key
         run: |
           printf '%s' '${{ steps.ephemeral.outputs.ephemeral-public-key }}' \
-            | base64 -d > ephemeral-public.asc
+            | base64 -d > repo-ephemeral-public.asc
 
       - name: Export repo public key
         run: |
-          echo '${{ secrets.GPG_REPO_CERT_B64 }}' | base64 -d > repo-public.asc
+          gpg --export --armor '${{ steps.ephemeral.outputs.repo-cert-keyid }}' > repo-public.asc
 
       - name: Find RPM file
         if: steps.get_version.outputs.version != '0.0.0'
@@ -247,6 +247,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ephemeral-public.asc
+          asset_path: repo-ephemeral-public.asc
           asset_name: repo_ephemeral_public.asc
           asset_content_type: text/plain

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Clean built RPMs in repo directory:
 make clean
 ```
 
+## Automated RPM Signing
+
+The GitHub release workflow signs built RPMs with the repository signing subkey
+stored in the `GPG_SUBKEY_B64` repository secret. The workflow also exports the
+matching ASCII-armored public key as a release asset so downstream consumers can
+verify the published RPM signature.
+
 ## Current Release
 
 OpenCHAMI is in development without an initial release.  We expect a first supported release in Q1 2025.  If you would like to follow the most current, stable configuration, each of the partners maintains a deployment recipe that will become a release candidate in our [Deployment Recipes](https://github.com/OpenCHAMI/deployment-recipes) Repository.


### PR DESCRIPTION
This pull request updates the RPM build GitHub Actions workflow to improve security and automation by switching to ephemeral GPG keys for signing and modernizing variable usage and output handling. The changes eliminate the need for long-lived signing credentials and streamline the build and release process.

**Security and GPG Key Management:**

* Replaces importing a static GPG private key with generating an ephemeral GPG key for each build using the `OpenCHAMI/gpg-signing-manager` action. The ephemeral key is configured with a 1-day expiration and unique metadata per run. [[1]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6R26-R29) [[2]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6L37-R56)
* Updates all signing steps (source tarball and RPMs) to use the ephemeral key's fingerprint, removing dependencies on static secrets and passphrases.
* Adds a step to export the ephemeral public key for distribution, replacing the previous export of a static public key. [[1]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6R81-R88) [[2]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6L83-R182)

**Workflow Modernization and Output Handling:**

* Refactors output variable usage to use the new `GITHUB_OUTPUT` mechanism instead of deprecated `set-output`, and consistently uses the dynamically determined version from the `get_version` step. [[1]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6R81-R88) [[2]](diffhunk://#diff-5a08ccff5b3a28e08436eb235807593aab89cbd5ae3988dddb421996e65ae2b6L83-R182)
* Updates conditional steps and asset naming to reference the dynamically determined version, ensuring consistency throughout the workflow.

**Build Process Improvements:**

* Simplifies the source tarball creation by removing unnecessary transformations and using the correct version variable.

These changes increase the security of the RPM build pipeline and align the workflow with current GitHub Actions best practices.
