### PR TITLE
Bump coresmd image to v0.6.2

### DIFF
--- a/systemd/containers/coresmd-coredhcp.container
+++ b/systemd/containers/coresmd-coredhcp.container
@@ -8,7 +8,7 @@ PartOf=openchami.target
 ContainerName=coresmd-coredhcp
 
 HostName=coresmd-coredhcp
-Image=ghcr.io/openchami/coresmd:v0.4.3
+Image=ghcr.io/openchami/coresmd:v0.6.2
 
 # Capabilities
 AddCapability=NET_ADMIN

--- a/systemd/containers/coresmd-coredns.container
+++ b/systemd/containers/coresmd-coredns.container
@@ -8,7 +8,7 @@ PartOf=openchami.target
 ContainerName=coresmd-coredns
 
 HostName=coresmd-coredns
-Image=ghcr.io/openchami/coresmd:v0.4.3
+Image=ghcr.io/openchami/coresmd:v0.6.2
 
 Exec=/coredns
 


### PR DESCRIPTION
## Changes

Update both coresmd container quadlets from `v0.4.3` to `v0.6.2`:

- `systemd/containers/coresmd-coredhcp.container`
- `systemd/containers/coresmd-coredns.container`

## Release

https://github.com/OpenCHAMI/coresmd/releases/tag/v0.6.2