### PR TITLE
fix: changes to allow running systemctl enable openchami.target

### DIFF
--- a/systemd/targets/openchami.target
+++ b/systemd/targets/openchami.target
@@ -1,5 +1,8 @@
 [Unit]
 Description=Group of OpenCHAMI-related services
-Requires=bss.service smd.service opaal.service cloud-init-server.service coresmd-coredhcp.service step-ca.service haproxy.service
+Requires=bss.service smd.service opaal.service cloud-init-server.service coresmd-coredhcp.service step-ca.service haproxy.service network-online.target
 Wants=coresmd-coredns.service
-After=bss-init.service smd-init.service postgres.service coresmd-coredns.service
+After=bss-init.service smd-init.service postgres.service coresmd-coredns.service network-online.target
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x ] My code follows the style guidelines of this project  
- [ x] I have added/updated comments where needed  
- [ ] I have added tests that prove my fix is effective or my feature works  
- [ x] I have run `make test` (or equivalent) locally and all tests pass  
- [x ] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

Adds possibility to start OpenCHAMI at boot time by running 'systemctl enable openchami.target'.
All existing functionality remains unimpaired.
Tested multiple times on various RHEL9 and Rocky10 systems.

Fixes #59 

### Type of Change

- [ ] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
