### PR TITLE
Add GitHub Action to trigger vTDS test deployment

### DIFF
--- a/.github/workflows/vtds-deploy.yaml
+++ b/.github/workflows/vtds-deploy.yaml
@@ -1,0 +1,107 @@
+name: "Deploy vTDS test instance on /deploy from approved user"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  deploy:
+    if: |
+      github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate OpenCHAMI GitHub App token
+        id: ochami-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.OCHAMI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OCHAMI_APP_PRIVATE_KEY }}
+          owner: openchami
+          repositories: |
+            release
+
+      - name: Generate HPE GitHub App token
+        id: hpe-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HPE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HPE_APP_PRIVATE_KEY }}
+          owner: cray-hpe
+          repositories: |
+            openchami-vtds
+
+      - name: Trigger vTDS deployment
+        uses: actions/github-script@v9
+        env:
+          HPE_TOKEN: ${{ steps.app-token.outputs.hpe-app-token }}
+        with:
+          github-token: ${{ steps.app-token.outputs.ochami-app-token }}
+          script: |
+            const hpeOrg = getOctokit(process.env.HPE_TOKEN);
+
+            // Current repository (openchami/release). github-token handles auth
+            // for this.
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+
+            const permission =
+              await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: commenter
+              });
+
+            const level = permission.data.permission;
+
+            // Only allow writers, maintainers, and admins to run /deploy.
+            if (!["write", "maintain", "admin"].includes(level)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `@${commenter} is not authorized to deploy.`
+              });
+
+              core.setFailed(
+                `User ${commenter} has permission level ${level}`
+              );
+              return;
+            }
+
+            // Use the ref the PR branch HEAD points to.
+            const pr =
+              await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issue_number
+              });
+
+            const sha = pr.data.head.sha;
+
+            // Use HPE GitHub App auth token here to trigger vTDS deployment
+            // workflow in cray-hpe/openchami-vtds.
+            await hpeOrg.rest.actions.createWorkflowDispatch({
+              owner: "cray-hpe",
+              repo: "openchami-vtds",
+              workflow_id: "vtds.yml",
+              ref: "main",
+              inputs: {
+                pr_number: String(issue_number),
+                ref: sha
+              }
+            });
+
+            // Post an informative comment.
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `Deployment queued for SHA: ${sha}.`
+            });


### PR DESCRIPTION
## Pull Request Template

### Description

This changeset adds a GitHub Action that will trigger vTDS deployments from pull request branches when an approved user (i.e. one with writer, maintianer, or admin permissions) comments /deploy on a pull request. The action will then deploy the HEAD of the PR branch.

It does this primarily with github-script@v9, which is a GitHub-provided utility action for interacting with the GitHub API in a more friendly manner via JavaScript. That code looks for the `/deploy` comment, checks it against the commenter's repository access, and then triggers a deployment if the user has the correct acess.

This functionality sidesteps several GitHub Actions-related security risks, especially if pull requests are made from forks.

### Additional work

This requires some out-of-band work that only a select few admins/org owners can provide, namely:

1. A GitHub app in the OpenCHAMI GitHub org with the following permissions:
   - Read and write Repository Contents.
   - Read and write Issues.
   - Read and write Pull Requests.
   - Read-only Metadata (mandatory).
2. A GitHub app in the HPE GitHub org with the following permissions:
   - Read and write GitHub Actions.
   - Read-only Metadata (mandatory).

The OpenCHAMI GitHub App is necessary for the action to do things like read PR comments, while the Cray-HPE GitHub App is necessary to trigger the `workflow_dispatch` endpoint to kick off the vTDS deployment action.

Then, the following secrets need to be created within the OpenCHAMI/release repository:
- `OCHAMI_APP_CLIENT_ID`: the installed OpenCHAMI GitHub App client ID
- `OCHAMI_APP_PRIVATE_KEY`: the installed OpenCHAMI GitHub App private key

Additionally, the following secrets need to be created within the Cray-HPE/openchami-vtds repository:
- `HPE_APP_CLIENT_ID`: the installed HPE GitHub App client ID
- `HPE_APP_PRIVATE_KEY`: the installed HPE GitHub App private key

### Caveats

Testing this involved working from private repositories under the same GitHub user, which changes the permissions structure a bit. I believe the `github-script` code should work as written, but there's a small chance there's a syntax error or something; it's just difficult to test cross-org permissions stuff like this. I'm happy to fix anything that breaks, just let me know.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added/updated comments where needed
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email
- [x] **REUSE Compliance**:
  - [x] Each new/modified source file has SPDX copyright and license headers
  - [x] Any non-commentable files include a `<filename>.license` sidecar
  - [x] All referenced licenses are present in the `LICENSES/` directory

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).