### PR TITLE
Fix GitHub token step output reference to use correct step names.

### DIFF
--- a/.github/workflows/vtds-deploy.yaml
+++ b/.github/workflows/vtds-deploy.yaml
@@ -38,9 +38,9 @@ jobs:
       - name: Trigger vTDS deployment
         uses: actions/github-script@v9
         env:
-          HPE_TOKEN: ${{ steps.app-token.outputs.hpe-app-token }}
+          HPE_TOKEN: ${{ steps.hpe-app-token.outputs.hpe-app-token }}
         with:
-          github-token: ${{ steps.app-token.outputs.ochami-app-token }}
+          github-token: ${{ steps.ochami-app-token.outputs.ochami-app-token }}
           script: |
             const hpeOrg = getOctokit(process.env.HPE_TOKEN);
 


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

This changeset fixes references to non-existent step outputs in the vTDS deployment GitHub Action workflow.

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
